### PR TITLE
Update check-and-lint.yaml

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -20,8 +20,7 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: xtask
-          args: check
+          command: check
 
   rustfmt:
     name: Rustfmt
@@ -36,5 +35,5 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: xtask
-          args: fmt -- --all --check
+          command: fmt
+          args: --all --check


### PR DESCRIPTION
After moving to a cargo workspaces setup, xtask is no longer required to run `check` and `fmt`.