### PR TITLE
Fix limine version

### DIFF
--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -13,7 +13,7 @@ path = "../libkernel"
 
 [dependencies]
 libsys = { git = "https://github.com/linuiz-project/libsys" }
-limine = { version = "0.4", features = ["uuid"] }
+limine = { version = "0.5", features = ["uuid"] }
 log = { version = "0.4", default-features = false }
 getrandom = "0.3"
 rand_pcg = { version = "0.9", default-features = false }


### PR DESCRIPTION
Fixes the `limine-rs` version on the main branch (`v0.4.0` was yanked).